### PR TITLE
Only Change AWS Credentials Based on Environment if Environment Variables actually exists

### DIFF
--- a/cmd/in/graphql/graphqlServer.go
+++ b/cmd/in/graphql/graphqlServer.go
@@ -1,35 +1,34 @@
 package in_graphql
 
 import (
-	"net/http"
-	"log"
-	"io/ioutil"
+	"encoding/json"
 	"finderio/cmd/service"
 	"finderio/cmd/setup"
-	"encoding/json"
-
+	"io/ioutil"
+	"log"
+	"net/http"
 )
-type errorResponse struct  {
+
+type errorResponse struct {
 	message string
 }
 
-func CreateServer (confSetup *setup.ConfSetup)  {
-
+func CreateServer(confSetup *setup.ConfSetup) {
 
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
 		encoder := json.NewEncoder(w)
 		body, _ := ioutil.ReadAll(r.Body)
 		jsonString := string(body)
 		result, err := service.Service(jsonString, confSetup)
-		if(err != nil){
+		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			eJson := make(map[string]interface{})
-			eJson["ERROR_MESSAGE"]=err.Error()
+			eJson["ERROR_MESSAGE"] = err.Error()
 			encoder.Encode(eJson)
-		}else{
+		} else {
 			encoder.Encode(result)
 		}
-		return 
+		return
 
 	})
 	log.Println("Server running on PORT: 8080")

--- a/cmd/out/dynamoDB/getItem.go
+++ b/cmd/out/dynamoDB/getItem.go
@@ -1,39 +1,35 @@
 package out_dynamodb
 
 import (
-
-
+	"errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"log"
-	"errors"
-	
 )
 
 type QueryData struct {
-
 	TableName string
-	KeyName string
-	Value string 
+	KeyName   string
+	Value     string
 }
 
-func UnmarshalDynamoAttributes (atributeMap map[string]*dynamodb.AttributeValue ) map[string]interface{} {
-	
+func UnmarshalDynamoAttributes(atributeMap map[string]*dynamodb.AttributeValue) map[string]interface{} {
+
 	var f map[string]interface{}
-	err:=dynamodbattribute.UnmarshalMap(atributeMap, &f)
-	if(err!=nil){
+	err := dynamodbattribute.UnmarshalMap(atributeMap, &f)
+	if err != nil {
 		panic(err)
 	}
 	return f
 }
 
-func GetItem (svc *dynamodb.DynamoDB, query QueryData) (map[string]*dynamodb.AttributeValue, error) {
+func GetItem(svc *dynamodb.DynamoDB, query QueryData) (map[string]*dynamodb.AttributeValue, error) {
 
 	result, err := svc.GetItem(&dynamodb.GetItemInput{
 		TableName: aws.String(query.TableName),
 		Key: map[string]*dynamodb.AttributeValue{
-			query.KeyName : {
+			query.KeyName: {
 				S: aws.String(query.Value),
 			},
 		},
@@ -46,10 +42,8 @@ func GetItem (svc *dynamodb.DynamoDB, query QueryData) (map[string]*dynamodb.Att
 		msg := "Could not find '" + query.Value + "'"
 		log.Println(msg)
 		return nil, errors.New(msg)
-		
-		
+
 	}
 
-	
 	return result.Item, nil
 }

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -1,28 +1,26 @@
 package service
 
-
-import(
-	
-	"log"
-	"finderio/cmd/setup"
+import (
 	"finderio/cmd/out/dynamoDB"
+	"finderio/cmd/setup"
 	"finderio/cmd/util"
+	"log"
 )
 
-func Service (jsonString string, confSetup *setup.ConfSetup) (map[string]interface {}, error) {
+func Service(jsonString string, confSetup *setup.ConfSetup) (map[string]interface{}, error) {
 
-	objectQuery:=util.GraphqlUnmarshal(jsonString);
+	objectQuery := util.GraphqlUnmarshal(jsonString)
 	log.Println(objectQuery)
-	queryData:=out_dynamodb.QueryData{objectQuery.TableName, objectQuery.HashKey , objectQuery.HashValue}
-	queryResult, err:=out_dynamodb.GetItem(confSetup.DynamoClient, queryData)
-	if(err != nil){
+	queryData := out_dynamodb.QueryData{objectQuery.TableName, objectQuery.HashKey, objectQuery.HashValue}
+	queryResult, err := out_dynamodb.GetItem(confSetup.DynamoClient, queryData)
+	if err != nil {
 		log.Println(err)
 		return nil, err
 	}
-	objectResult:=out_dynamodb.UnmarshalDynamoAttributes(queryResult)
+	objectResult := out_dynamodb.UnmarshalDynamoAttributes(queryResult)
 	log.Println(queryResult)
-	returnableObject:=make(map[string]interface{})
-	for _, value := range(objectQuery.Items) {
+	returnableObject := make(map[string]interface{})
+	for _, value := range objectQuery.Items {
 		returnableObject[value] = objectResult[value]
 	}
 	log.Println(returnableObject)

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -21,9 +21,11 @@ func envVarSetup() {
 	REGION:=os.Getenv("FINDERIO_REGION")
 	ID:=os.Getenv("FINDERIO_ID")
 	SECRET:=os.Getenv("FINDERIO_SECRET")
-	os.Setenv("AWS_REGION", REGION)
-	os.Setenv("AWS_ACCESS_KEY_ID", ID)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", SECRET)
+	if (REGION != "" && ID != "" && SECRET != "") {
+		os.Setenv("AWS_REGION", REGION)
+		os.Setenv("AWS_ACCESS_KEY_ID", ID)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", SECRET)
+	}
 }
 
 func sessionSetup() *ConfSetup {
@@ -44,7 +46,6 @@ func sessionSetup() *ConfSetup {
 
 
 func MainSetup() *ConfSetup{
-
 	envVarSetup()
 	confSetup:=sessionSetup()
 	log.Println("End of setup")

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -46,6 +46,7 @@ func sessionSetup() *ConfSetup {
 
 
 func MainSetup() *ConfSetup{
+	
 	envVarSetup()
 	confSetup:=sessionSetup()
 	log.Println("End of setup")

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -1,27 +1,24 @@
-package setup 
+package setup
 
 import (
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"log"
 	"os"
 )
 
 type ConfSetup struct {
-
-	Session *session.Session
+	Session      *session.Session
 	DynamoClient *dynamodb.DynamoDB
-
 }
-
 
 func envVarSetup() {
 
 	log.Println("Loading Env Var")
-	REGION:=os.Getenv("FINDERIO_REGION")
-	ID:=os.Getenv("FINDERIO_ID")
-	SECRET:=os.Getenv("FINDERIO_SECRET")
-	if (REGION != "" && ID != "" && SECRET != "") {
+	REGION := os.Getenv("FINDERIO_REGION")
+	ID := os.Getenv("FINDERIO_ID")
+	SECRET := os.Getenv("FINDERIO_SECRET")
+	if REGION != "" && ID != "" && SECRET != "" {
 		os.Setenv("AWS_REGION", REGION)
 		os.Setenv("AWS_ACCESS_KEY_ID", ID)
 		os.Setenv("AWS_SECRET_ACCESS_KEY", SECRET)
@@ -34,21 +31,18 @@ func sessionSetup() *ConfSetup {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
-	
+
 	// Create DynamoDB client
 	svc := dynamodb.New(sess)
 
-	return &ConfSetup{sess,svc}
+	return &ConfSetup{sess, svc}
 
 }
 
+func MainSetup() *ConfSetup {
 
-
-
-func MainSetup() *ConfSetup{
-	
 	envVarSetup()
-	confSetup:=sessionSetup()
+	confSetup := sessionSetup()
 	log.Println("End of setup")
-	return confSetup;
+	return confSetup
 }

--- a/cmd/util/dynamoDbUnmarshal.go
+++ b/cmd/util/dynamoDbUnmarshal.go
@@ -1,19 +1,18 @@
 package util
 
 import (
-	"strings"
 	"log"
+	"strings"
 )
 
-func getItem (jsonString string) string {
+func getItem(jsonString string) string {
 
-	i:=strings.Index(jsonString, string(rune(34)))
+	i := strings.Index(jsonString, string(rune(34)))
 	log.Println(jsonString[i:])
 	return jsonString
 }
 
-func DynamoUnmarshal(jsonString string) string{
-
+func DynamoUnmarshal(jsonString string) string {
 
 	return getItem(jsonString)
 

--- a/cmd/util/graphqlUnmarshal.go
+++ b/cmd/util/graphqlUnmarshal.go
@@ -1,86 +1,82 @@
 package util
 
-import(
-	"strings"
+import (
 	"log"
+	"strings"
 )
 
 type QueryObject struct {
-
 	TableName string
-	HashKey string
+	HashKey   string
 	HashValue string
-	Items []string
-	
-
+	Items     []string
 }
 
-
 func getTableName(jsonString string) (string, string) {
-	i:=strings.Index(jsonString, "query")
+	i := strings.Index(jsonString, "query")
 	jsonString = jsonString[i:]
-	i=strings.Index(jsonString, "{")
-	jsonString=jsonString[i+3:]
-	i=0 
-	for jsonString[i] == ' '{
+	i = strings.Index(jsonString, "{")
+	jsonString = jsonString[i+3:]
+	i = 0
+	for jsonString[i] == ' ' {
 		i++
 	}
 	auxString := jsonString[i:]
-	i=0
-	for auxString[i] != ' '{
+	i = 0
+	for auxString[i] != ' ' {
 		i++
 	}
-	tableName:=auxString[:i]
+	tableName := auxString[:i]
 	log.Println("TABLE NAME", tableName)
-	jsonString=auxString[i:]
+	jsonString = auxString[i:]
 	return jsonString, tableName
 }
 
-func getHashKey(jsonString string) (string, string){
-	i:=strings.Index(jsonString, "(")
+func getHashKey(jsonString string) (string, string) {
+	i := strings.Index(jsonString, "(")
 	jsonString = jsonString[i+1:]
-	i=strings.Index(jsonString, ":")
-	hashKey:=jsonString[:i]
+	i = strings.Index(jsonString, ":")
+	hashKey := jsonString[:i]
 	log.Println("HASH KEY", hashKey)
-	jsonString=jsonString[i+3:]
+	jsonString = jsonString[i+3:]
 	return jsonString, hashKey
 }
 
 func getHashValue(jsonString string) (string, string) {
-	i:=strings.Index(jsonString, ")")
-	hashValue:=jsonString[:i-2]
+	i := strings.Index(jsonString, ")")
+	hashValue := jsonString[:i-2]
 	log.Println("HASH VALUE", hashValue)
-	jsonString=jsonString[i:]
+	jsonString = jsonString[i:]
 	return jsonString, hashValue
 }
 
 func getItems(jsonString string, valueArray []string) (string, []string) {
-	i:=strings.Index(jsonString, "n")
-	jsonString=jsonString[i+1:]
-	i=0
-	for jsonString[i] == ' '{
+	i := strings.Index(jsonString, "n")
+	jsonString = jsonString[i+1:]
+	i = 0
+	for jsonString[i] == ' ' {
 		i++
 	}
-	if(jsonString[i] == '}'){
+	if jsonString[i] == '}' {
 		return jsonString, valueArray
 	}
-	jsonString=jsonString[i:]
-	i=strings.Index(jsonString, "n")
-	value:=jsonString[:i-1]
+	jsonString = jsonString[i:]
+	i = strings.Index(jsonString, "n")
+	value := jsonString[:i-1]
 	log.Println("VALOR:", value)
 	valueArray = append(valueArray, value)
-	return getItems(jsonString,valueArray)
+	return getItems(jsonString, valueArray)
 
 }
 
-func GraphqlUnmarshal(jsonString string) (*QueryObject){
+func GraphqlUnmarshal(jsonString string) *QueryObject {
 
-	jsonString, tableName := getTableName(jsonString);
+	jsonString, tableName := getTableName(jsonString)
 	jsonString, hashKey := getHashKey(jsonString)
-	jsonString, hashValue:=getHashValue(jsonString)
+	jsonString, hashValue := getHashValue(jsonString)
 	var valueArray []string
 	jsonString, valueArray = getItems(jsonString, valueArray)
 	return &QueryObject{TableName: tableName,
-	HashKey: hashKey, HashValue: hashValue, Items: valueArray}
+		HashKey: hashKey, HashValue: hashValue, Items: valueArray}
 
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,11 @@
 package main
 
-import(
-
-	"finderio/cmd/setup"
+import (
 	"finderio/cmd/in/graphql"
+	"finderio/cmd/setup"
 )
 
-func main(){
-	confSetup:=setup.MainSetup()
-	in_graphql.CreateServer(confSetup);
+func main() {
+	confSetup := setup.MainSetup()
+	in_graphql.CreateServer(confSetup)
 }


### PR DESCRIPTION
currently, if the envs are not set, it will cause the environment to override the existing credentials variables if someone wants to configure it that way. Also it might cause issues if you want to use a service role on the app in EC2/Fargate, it will cause the application to not utilize it. So this PR makes it so the OS envs are only set if the creds are not empty. 